### PR TITLE
Fixed byte length

### DIFF
--- a/Source/ClassLibrary/RegExpPerl.cs
+++ b/Source/ClassLibrary/RegExpPerl.cs
@@ -2692,9 +2692,9 @@ namespace PHP.Library
                                     }
                                     else
                                     {
-                                        for (byte b = (byte)(from + 1); b < 255 && b <= to; b++)
+                                        for (int j = from + 1; j <= to; j++)
                                         {
-                                            var chars = encoding.GetChars(new[] { b });
+                                            var chars = encoding.GetChars(new[] { (byte)j });
                                             AppendEscaped(result, chars[0]);
                                         }
                                     }


### PR DESCRIPTION
Ran tests using wikiLingo, and it would not complete.  Changing this
made the regex work flawless.
