### PR TITLE
add errorInfo setter to PDOException.

### DIFF
--- a/Source/Extensions/PDO/PDOException.cs
+++ b/Source/Extensions/PDO/PDOException.cs
@@ -58,7 +58,10 @@ namespace PHP.Library.Data
         }
 
         [PhpVisible]
-        public PhpArray errorInfo { get { return this.m_errorInfo; } }
+        public PhpArray errorInfo { 
+            get { return this.m_errorInfo; }
+            set { this.m_errorInfo = value; }
+        }
 
         public static void Throw(ScriptContext context, string message, PhpArray errorInfo, object code, object previous)
         {


### PR DESCRIPTION
example of Doctrine/DBAL using errorInfo setter: https://github.com/doctrine/dbal/blob/89d4f06fb4ff6e7b8f3c29a7307bf66203e09922/lib/Doctrine/DBAL/Driver/PDOException.php#L55